### PR TITLE
Fixed publication date on release 1.1.7

### DIFF
--- a/Tools/Docusaurus/news/releases/release-1.1.7.md
+++ b/Tools/Docusaurus/news/releases/release-1.1.7.md
@@ -1,7 +1,7 @@
 ---
 slug: release-1.1.7
 title: Release 1.1.7
-date: 2022-12-02
+date: 2023-02-23
 authors: [merlin]
 tags: [release]
 draft: false


### PR DESCRIPTION
Release 1.1.7 was set to the same date as 1.1.6 and thus was sorting below it